### PR TITLE
isNumber validator method was missing a return true statement.

### DIFF
--- a/core/components/formit/model/formit/fivalidator.class.php
+++ b/core/components/formit/model/formit/fivalidator.class.php
@@ -348,6 +348,7 @@ class fiValidator {
          if (!is_numeric($value)) {
              return $this->modx->lexicon('formit.not_number');
          }
+         return true;
      }
 
     /**


### PR DESCRIPTION
The isNumber method in fivalidator.class.php was returning an empty error message even on success. I added a 'return true' line to it and it seems to work as intended now.
