### PR TITLE
fiValidator: Fixed major security/ validation hole, and 2 minor code fixes. 

### DIFF
--- a/core/components/formit/model/formit/fivalidator.class.php
+++ b/core/components/formit/model/formit/fivalidator.class.php
@@ -81,7 +81,7 @@ class fiValidator {
      * @return array An array of field name => value pairs.
      */
     public function validateFields(array $keys = array(),$validationFields = '') {
-        $this->fields = $fields;
+        $this->fields = array();
 
         /* process the list of fields that will be validated */
         $validationFields = explode(',',$validationFields);
@@ -219,6 +219,9 @@ class fiValidator {
     public function addError($key,$value) {
         $errTpl = $this->modx->getOption('errTpl',$this->formit->config,'<span class="error">[[+error]]</span>');
         $this->errorsRaw[$key] = $value;
+        if (!isset($this->errors[$key])) {
+            $this->errors[$key] = '';
+        }
         $this->errors[$key] .= ' '.str_replace('[[+error]]',$value,$errTpl);
         return $this->errors[$key];
     }

--- a/core/components/formit/model/formit/fivalidator.class.php
+++ b/core/components/formit/model/formit/fivalidator.class.php
@@ -93,6 +93,9 @@ class fiValidator {
                 $field = $key[0];
                 array_splice($key,0,1); /* remove the field name from validator list */
                 $fieldValidators[$field] = $key;
+                if (!isset($keys[$field])) { /* prevent someone from bypassing a required field by removing it from the form */
+                    $keys[$field] = '';
+                }
             }
         }
 


### PR DESCRIPTION
Ideally, these should be applied to both production and development branches. Sorry, this is my first pull request, so I'm not sure how to do that.

Line 84: $fields is not set - did you mean $keys, or to leave it empty?

Line 96-98: Fixed major security/ functionality hole. This prevents users from bypassing required fields by simply removing them from the form (i.e. with a tool like Developer Tools).

Line 222-224: Concatenating a non-existent value was causing warning-level errors.
