### PR TITLE
Check for $_POST[$submitVar] instead of $_POST to prevent preHooks setting fields.

### DIFF
--- a/core/components/formit/elements/snippets/snippet.formit.php
+++ b/core/components/formit/elements/snippets/snippet.formit.php
@@ -84,7 +84,7 @@ $fi->preHooks->loadMultiple($preHooks,array(),array(
 ));
 
 /* if a prehook sets a field, do so here, but only if POST isnt submitted */
-if (!empty($fi->preHooks->fields) && empty($_POST)) {
+if (!empty($fi->preHooks->fields) && empty($_POST[$submitVar])) {
     $fs = $fi->preHooks->fields;
     /* better handling of checkbox values when input name is an array[] */
     foreach ($fs as $f => $v) {


### PR DESCRIPTION
Fixed bug where if another form with a different submitvar on the page was submitted, preHooks would not set fields.
