### PR TITLE
Fix Bug: Send config to the prehooks.

### DIFF
--- a/core/components/formit/model/formit/firequest.class.php
+++ b/core/components/formit/model/formit/firequest.class.php
@@ -123,7 +123,7 @@ class fiRequest {
      */
     public function runPreHooks() {
         $fields = array();
-        $this->formit->loadHooks('pre');
+        $this->formit->loadHooks('pre',$this->config);
         $this->formit->preHooks->loadMultiple($this->config['preHooks'],array(),array(
             'submitVar' => $this->config['submitVar'],
             'hooks' => $this->config['preHooks'],

--- a/core/components/formit/model/formit/firequest.class.php
+++ b/core/components/formit/model/formit/firequest.class.php
@@ -291,7 +291,7 @@ class fiRequest {
     public function runPostHooks() {
         $success = true;
         /* load posthooks */
-        $this->formit->loadHooks('post');
+        $this->formit->loadHooks('post',$this->config);
         $this->formit->postHooks->loadMultiple($this->config['hooks'],$this->dictionary->toArray());
 
         /* process form */


### PR DESCRIPTION
Without sending the config to the prehooks, placeholders are set using the default placeholder. This means that forms with custom placeholderPrefix values can no longer set values via prehooks. This fixes that bug.
