### PR TITLE
Fix for useIsoCode

### DIFF
--- a/core/components/formit/model/formit/module/ficountryoptions.class.php
+++ b/core/components/formit/model/formit/module/ficountryoptions.class.php
@@ -52,7 +52,7 @@ class fiCountryOptions extends fiModule {
             'outputSeparator' => "\n",
             'toPlaceholder' => '',
         ));
-        $this->setOption('selectedKey',$this->getOption('useIsoCode',true) ? 'countryKey' : 'countryName');
+        $this->setOption('selectedKey',$this->getOption('useIsoCode',true,'isset') ? 'countryKey' : 'countryName');
     }
 
     /**


### PR DESCRIPTION
If I pass the option &useIsoCode=`0`, the selected country doesn't get selected, this is due to the $selectedKey always being set to countryKey.
