### PR TITLE
Patch multi dimensional array fields

### DIFF
--- a/core/components/formit/model/formit/fihooks.class.php
+++ b/core/components/formit/model/formit/fihooks.class.php
@@ -442,7 +442,7 @@ class fiHooks {
                 if (empty($v['name'])) {
                     $v['name'] = 'attachment'.$attachmentIndex;
                 }
-                $this->modx->mail->mailer->AddAttachment($v['tmp_name'],$v['name'],'base64',!empty($v['type']) ? $v['type'] : 'application/octet-stream');
+                $this->modx->mail->mailer->addAttachment($v['tmp_name'],$v['name'],'base64',!empty($v['type']) ? $v['type'] : 'application/octet-stream');
                 $attachmentIndex++;
             }
         }


### PR DESCRIPTION
with optional to use dynamicFieldTpls property for dynamic HTML form added by javascript.
Fallback to implode them with commas to be used by the original Formit's checkboxes snippet.
