### PR TITLE
Allow full templating of validationErrorBulkTpl.

### DIFF
--- a/core/components/formit/model/formit/fivalidator.class.php
+++ b/core/components/formit/model/formit/fivalidator.class.php
@@ -683,8 +683,10 @@ class fiValidator {
         $this->modx->toPlaceholders($this->getErrors(),$this->config['placeholderPrefix'].'error');
         $errs = array();
         foreach ($this->getRawErrors() as $field => $err) {
-            $err = $field.': '.$err;
-            $errs[] = str_replace('[[+error]]',$err,$this->config['validationErrorBulkTpl']);
+            $haystack = $this->config['validationErrorBulkTpl'];
+            $search   = array('[[+field]]','[[+error]]');
+            $replace  = array($field,$err);
+            $errs[]   = str_replace( $search , $replace , $haystack );
         }
         $errs = implode($this->config['validationErrorBulkSeparator'],$errs);
         $validationErrorMessage = str_replace('[[+errors]]',$errs,$this->config['validationErrorMessage']);


### PR DESCRIPTION
This give you the option to create anchor links inside validationErrorBulkTpl.

Examples: 

&validationErrorBulkTpl=`<li><a href="[[~[[*id]]]]#[[+field]]">[[+field]]</a>: [[+error]]</li>`
&validationErrorBulkTpl=`<li>[[field]]: [[+error]] <a href="[[~[[*id]]]]#[[+field]]">(*)</a></li>`
