### PR TITLE
Develop

### DIFF
--- a/core/components/formit/elements/snippets/snippet.formitischecked.php
+++ b/core/components/formit/elements/snippets/snippet.formitischecked.php
@@ -30,10 +30,8 @@ $output = ' ';
 if ($input == $options) {
     $output = ' checked="checked"';
 }
-if (strpos($input,',') !== false) {
-    $input = explode(',',$input);
-    if (in_array($options,$input)) {
-        $output = ' checked="checked"';
-    }
+$input = $modx->fromJSON($input);
+if (in_array($options,$input)) {
+  $output = ' checked="checked"';
 }
 return $output;

--- a/core/components/formit/elements/snippets/snippet.formitisselected.php
+++ b/core/components/formit/elements/snippets/snippet.formitisselected.php
@@ -30,10 +30,8 @@ $output = ' ';
 if ($input == $options) {
     $output = ' selected="selected"';
 }
-if (strpos($input,',') !== false) {
-    $input = explode(',',$input);
-    if (in_array($options,$input)) {
-        $output = ' selected="selected"';
-    }
+$input = $modx->fromJSON($input);
+if (in_array($options,$input)) {
+  $output = ' selected="selected"';
 }
 return $output;

--- a/core/components/formit/elements/snippets/snippet.formitretriever.php
+++ b/core/components/formit/elements/snippets/snippet.formitretriever.php
@@ -42,6 +42,12 @@ $fi->request->loadDictionary();
 $data = $fi->request->dictionary->retrieve();
 if (!empty($data)) {
     /* set data to placeholders */
+    foreach ($data as $k=>$v) {
+        /*checkboxes & other multi-values are stored as arrays, must be imploded*/
+        if (is_array($v)) {
+            $data[$k] = implode(',',$v);
+        }
+    }
     $modx->toPlaceholders($data,$placeholderPrefix,'');
     
     /* if set, erase the data on load, otherwise depend on cache expiry time */

--- a/core/components/formit/model/formit/firequest.class.php
+++ b/core/components/formit/model/formit/firequest.class.php
@@ -362,7 +362,7 @@ class fiRequest {
                 foreach ($v as $sk => $sv) {
                     $fs[$k.'.'.$sk] = $this->convertMODXTags($sv);
                 }
-                $v = implode(',',$v);
+                 $v = $this->modx->toJSON($v);
             }
             /* str_replace to prevent showing of placeholders */
             $fs[$k] = $this->convertMODXTags($v);
@@ -371,7 +371,7 @@ class fiRequest {
     }
 
     public function convertMODXTags($v) {
-        return str_replace(array('[',']'),array('&#91;','&#93;'),$v);
+        return str_replace(array('[[',']]'),array('&#91;&#91;','&#93;&#93;'),$v);
     }
 }
  


### PR DESCRIPTION
Fixes a bug in FormItIsChecked & FormItIsSelected by changing the way multi-value form arrays are passed (switched from a comma-delimited list to JSON). Without this fix, field values that contain a comma were corrupting the way the explode() function turned the string back in to an array in these output filter snippets.
