### PR TITLE
"vTextPasswordConfirm" update

### DIFF
--- a/core/components/formit/model/formit/fivalidator.class.php
+++ b/core/components/formit/model/formit/fivalidator.class.php
@@ -374,7 +374,16 @@ class fiValidator {
      * @return boolean
      */
     public function password_confirm($key,$value,$param = 'password_confirm') {
-        if (empty($value)) return $this->modx->lexicon('formit.password_not_confirmed');
+        // if (empty($value)) return $this->modx->lexicon('formit.password_not_confirmed');
+
+        if (empty($value)) {
+            return $this->_getErrorMessage($key,'vTextPasswordConfirm','formit.password_dont_match',array(
+                'field' => $key,
+                'password' => $value,
+                'password_confirm' => $this->fields[$param],
+                ));
+        }
+
         if ($this->fields[$param] != $value) {
             return $this->_getErrorMessage($key,'vTextPasswordConfirm','formit.password_dont_match',array(
                 'field' => $key,


### PR DESCRIPTION
Custom error message for "vTextPasswordConfirm" was not honoured on Empty form field.

I am not sure if its correct way to do it, but it worked for me. Consider it a pull request if it makes sense.
