### PR TITLE
Update ficountryoptions.class.php

### DIFF
--- a/core/components/formit/model/formit/module/ficountryoptions.class.php
+++ b/core/components/formit/model/formit/module/ficountryoptions.class.php
@@ -60,7 +60,13 @@ class fiCountryOptions extends fiModule {
      * @return array
      */
     public function getData() {
-        $this->countries = include $this->formit->config['includesPath'].'countries.inc.php';
+        $cultureKey = $this->modx->getOption('cultureKey', array(), '', true);
+    	$countriesFile = $this->getOption('statesDirectory',$this->formit->config['includesPath']).$cultureKey.'.countries.inc.php';
+		if (file_exists($countriesFile)) {
+			$this->countries = include $countriesFile;
+		} else {
+		    $this->countries = include $this->formit->config['includesPath'].'countries.inc.php';
+        }
         return $this->countries;
     }
 


### PR DESCRIPTION
Will make it possible to translate the country listing options. This way it is based on the MODX cultureKey setting. Maybe good to add an overrule option too?
