### PR TITLE
preHooks and addError problem

### DIFF
--- a/core/components/formit/model/formit/firequest.class.php
+++ b/core/components/formit/model/formit/firequest.class.php
@@ -310,7 +310,7 @@ class fiRequest {
         $this->formit->postHooks->loadMultiple($this->config['hooks'],$this->dictionary->toArray());
 
         /* process form */
-        if ($this->formit->postHooks->hasErrors()) {
+        if ($this->formit->preHooks->hasErrors() || $this->formit->postHooks->hasErrors()) {
             $success = false;
             $this->formit->postHooks->processErrors();
         } else {


### PR DESCRIPTION
I have written a custom captcha and facing now the following problem:

The captcha is called as preHook (because it has to display the captcha). It is checking $_POST for the form field itself and if the check is successfull the preHook is calling addError and returns with false. 

This error seems not to be regarded later in request->postprocess, so the form is posted even with the error in preHook.

Checking for errors in preHooks could avoid that problem. So the snippet does not have to be called twice as pre- and postHook, which is the only solution at the moment.
