### PR TITLE
Update snippet.formitischecked.php

### DIFF
--- a/core/components/formit/elements/snippets/snippet.formitischecked.php
+++ b/core/components/formit/elements/snippets/snippet.formitischecked.php
@@ -31,7 +31,7 @@ if ($input == $options) {
     $output = ' checked="checked"';
 }
 $input = $modx->fromJSON($input);
-if (in_array($options,$input)) {
+if (!empty($input) && is_array($input) && in_array($options,$input)) {
   $output = ' checked="checked"';
 }
 return $output;


### PR DESCRIPTION
Because without this checks you will get an error when it's not an array?? But why at all?? You can only add this one to one single placeholder right? it isn't an array I guess?
