### PR TITLE
Update snippet.formitretriever.php

### DIFF
--- a/core/components/formit/elements/snippets/snippet.formitretriever.php
+++ b/core/components/formit/elements/snippets/snippet.formitretriever.php
@@ -40,6 +40,10 @@ $redirectToOnNotFound = $modx->getOption('redirectToOnNotFound',$scriptPropertie
 $fi->loadRequest();
 $fi->request->loadDictionary();
 $data = $fi->request->dictionary->retrieve();
+if (empty($data)) {
+    $data = $fi->request->runPreHooks();
+}
+
 if (!empty($data)) {
     /* set data to placeholders */
     foreach ($data as $k=>$v) {


### PR DESCRIPTION
With this change it's possible to have &preHooks on FormItRetriever. This is useful when doing custom loading and keep the nice "redirectToOnNotFound" feature.

For example;
I want to use the submission form for editting again and I link back to the form with some URL parameters (to identify the item to edit). In my custom preHook I can catch that, gather the fields and populate FormIt dictionairy with that. Normally when I go back to the form with a "FormItRetriever" and &redirectToOnNotFound set, the FormIt store file is no longer there or not valid anymore (storeTime expired). With a custom snippet you can set values and this will make the request valid again. 

With the if empty around the preHooks call it will make the submission values the most important and overrule the preHook stuff, that's perfect as far I can see.
